### PR TITLE
Add manual CI/CD deployment workflow and CLI tool

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,43 @@
+name: Build and Deploy Site
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: playasontech.com
+      url: https://playasontech.com/
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build static site
+        run: pnpm run build
+        env:
+          NEXT_PUBLIC_WEB3FORMS_KEY: ${{ secrets.NEXT_PUBLIC_WEB3FORMS_KEY }}
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./out
+          allow_empty_commit: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ npm install
 npm run dev        # Dev server — http://localhost:3000
 npm run build      # Static export → ./out  (type-checks + lints)
 npm run lint       # ESLint (next/core-web-vitals)
-npm run deploy     # Build, then publish ./out to the gh-pages branch
+npm run deploy-ci  # Sync commits, trigger GitHub Actions build/deploy, and verify online status
 ```
 
 ## Architecture
@@ -58,11 +58,10 @@ custom domain and `public/.nojekyll` stops GitHub Pages from stripping the
 
 ## Deploying (GitHub Pages)
 
-`npm run deploy` runs `next build` (producing `./out`, including `CNAME` and
-`.nojekyll`) and publishes it to the `gh-pages` branch via the `gh-pages`
-package. The live site (`playasontech.com`) is served from `gh-pages`, so
-merging to `main` does **not** change the live site until someone runs
-`npm run deploy`.
+`npm run deploy-ci` ensures all local commits are pushed, triggers the remote GitHub Actions build workflow (injecting environment variables securely via GitHub Secrets), lints and compiles the static export, deploys it to the `gh-pages` branch, and verifies the site's online status.
+
+The live site (`playasontech.com`) is served from `gh-pages`, so merging to `main` does **not** change the live site until someone runs `npm run deploy-ci`.
+
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm run dev        # http://localhost:3000
 ```bash
 npm run build      # static export → ./out (type-checks + lints)
 npm run lint       # ESLint
-npm run deploy     # build + publish ./out to the gh-pages branch
+npm run deploy-ci  # build + deploy via GitHub Actions CI (on-demand)
 ```
 
 ## Structure
@@ -48,5 +48,19 @@ public/
 
 ## Deploying
 
-The live site is served from the `gh-pages` branch. Run `npm run deploy` to
-build and publish. Merging to `main` does not change the live site on its own.
+The live site is served from the `gh-pages` branch. We build and deploy the site using a GitHub Actions workflow on-demand via the following command:
+
+```bash
+npm run deploy-ci
+```
+
+This triggers the remote workflow using your GitHub Secrets for environment variables (like `NEXT_PUBLIC_WEB3FORMS_KEY`), ensures your local commits are pushed, monitors the remote build status in your terminal, and pings the site once complete to verify it is online.
+
+**Requirements:**
+- Ensure `NEXT_PUBLIC_WEB3FORMS_KEY` is added to your repository's GitHub Secrets (**Settings > Secrets and variables > Actions**).
+- Authenticate locally by running `gh auth login` (GitHub CLI) once, or by setting a `GITHUB_TOKEN` environment variable.
+
+> [!NOTE]
+> Merging to `main` does not change the live site on its own; you must trigger a deployment using the command above.
+
+

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "predeploy": "npm run build",
-    "deploy": "gh-pages -d out -t"
+    "deploy-ci": "node scripts/deploy-ci.js"
   },
   "dependencies": {
     "next": "^16.2.6",
@@ -23,7 +22,6 @@
     "autoprefixer": "^10.4.20",
     "eslint": "^9.0.0",
     "eslint-config-next": "^16.2.6",
-    "gh-pages": "^6.1.1",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
     "typescript": "^5"

--- a/scripts/deploy-ci.js
+++ b/scripts/deploy-ci.js
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const WORKFLOW_NAME = "deploy.yml";
+
+// Helper to run git commands and get trimmed output
+function runGit(cmd) {
+  try {
+    return execSync(cmd, { stdio: ["ignore", "pipe", "ignore"] }).toString().trim();
+  } catch (error) {
+    return "";
+  }
+}
+
+// Check if a command exists in the shell environment
+function commandExists(cmd) {
+  try {
+    execSync(`where ${cmd}`, { stdio: "ignore" });
+    return true;
+  } catch (e) {
+    try {
+      execSync(`which ${cmd}`, { stdio: "ignore" });
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }
+}
+
+// 1. Get repository context
+const branch = runGit("git rev-parse --abbrev-ref HEAD") || "main";
+const headSha = runGit("git rev-parse HEAD");
+const remoteUrl = runGit("git remote get-url origin");
+
+if (!headSha || !remoteUrl) {
+  console.error("❌ Error: Must be run inside a valid Git repository with an 'origin' remote.");
+  process.exit(1);
+}
+
+// Parse owner and repo from remote URL
+// Handles both HTTPS and SSH URLs, and removes .git suffix
+try {
+  const pathPart = remoteUrl.split("github.com")[1].replace(/^[:/]/, "");
+  const parts = pathPart.split("/");
+  const owner = parts[0];
+  const repo = parts[1].replace(/\.git$/, "");
+  
+  if (!owner || !repo) {
+    throw new Error();
+  }
+  
+  global.owner = owner;
+  global.repo = repo;
+} catch (error) {
+  console.error(`❌ Error: Could not parse GitHub owner and repository name from remote URL: ${remoteUrl}`);
+  process.exit(1);
+}
+
+const owner = global.owner;
+const repo = global.repo;
+
+console.log(`🚀 Starting CI/CD Deployment Process for ${owner}/${repo}`);
+console.log(`📍 Current Branch: ${branch}`);
+console.log(`🔢 Target Commit SHA: ${headSha.substring(0, 7)}`);
+
+// 2. Sync local changes with remote
+console.log("\n🔍 Checking for unpushed commits...");
+const unpushed = runGit(`git cherry -v origin/${branch}`);
+if (unpushed) {
+  console.log("⚠️  Found local commits that are not on the remote repository.");
+  console.log("Pumping commits to origin so GitHub Actions can see the latest changes...");
+  try {
+    execSync(`git push origin ${branch}`, { stdio: "inherit" });
+    console.log("✅ Successfully pushed commits to GitHub.");
+  } catch (error) {
+    console.error("❌ Error: Failed to push commits to remote. Please push manually or check your connection.");
+    process.exit(1);
+  }
+} else {
+  console.log("✅ Remote is fully up to date with local commits.");
+}
+
+// 3. Determine Auth Strategy and check credentials
+let useGhCli = false;
+let apiToken = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+
+if (commandExists("gh")) {
+  try {
+    execSync("gh auth status", { stdio: "ignore" });
+    useGhCli = true;
+  } catch (e) {
+    // gh is installed but not authenticated
+  }
+}
+
+if (!useGhCli && !apiToken) {
+  console.error("\n❌ Error: Authentication required to trigger GitHub Actions.");
+  console.error("Please do one of the following:");
+  console.error("  1. Log in via the GitHub CLI: run 'gh auth login'");
+  console.error("  2. Or set a GITHUB_TOKEN or GH_TOKEN environment variable.");
+  process.exit(1);
+}
+
+console.log(useGhCli ? "🔑 Authenticated via GitHub CLI." : "🔑 Authenticated via GITHUB_TOKEN.");
+
+// Helper to poll workflow runs via GH CLI or API
+async function fetchWorkflowRuns() {
+  if (useGhCli) {
+    try {
+      const output = execSync(
+        `gh run list --workflow=${WORKFLOW_NAME} --branch=${branch} --limit=5 --json databaseId,status,conclusion,headSha,url`,
+        { stdio: ["ignore", "pipe", "ignore"] }
+      ).toString();
+      return JSON.parse(output).map(run => ({
+        id: run.databaseId,
+        status: run.status,
+        conclusion: run.conclusion,
+        headSha: run.headSha,
+        url: run.url
+      }));
+    } catch (e) {
+      return [];
+    }
+  } else {
+    try {
+      const response = await fetch(
+        `https://api.github.com/repos/${owner}/${repo}/actions/runs?workflow_id=${WORKFLOW_NAME}&branch=${branch}`,
+        {
+          headers: {
+            Authorization: `Bearer ${apiToken}`,
+            Accept: "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "playas-on-tech-deploy"
+          }
+        }
+      );
+      if (!response.ok) return [];
+      const data = await response.json();
+      return (data.workflow_runs || []).map(run => ({
+        id: run.id,
+        status: run.status,
+        conclusion: run.conclusion,
+        headSha: run.head_sha,
+        url: run.html_url
+      }));
+    } catch (e) {
+      return [];
+    }
+  }
+}
+
+// Helper to trigger the workflow run
+async function triggerWorkflow() {
+  console.log("\n⚡ Triggering GitHub Actions deploy workflow...");
+  if (useGhCli) {
+    execSync(`gh workflow run ${WORKFLOW_NAME} --ref ${branch}`);
+  } else {
+    const response = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${WORKFLOW_NAME}/dispatches`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiToken}`,
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+          "Content-Type": "application/json",
+          "User-Agent": "playas-on-tech-deploy"
+        },
+        body: JSON.stringify({ ref: branch })
+      }
+    );
+    if (!response.ok) {
+      const errText = await response.text();
+      throw new Error(`GitHub API returned status ${response.status}: ${errText}`);
+    }
+  }
+}
+
+async function main() {
+  try {
+    // Record current runs before triggering so we don't accidentally pick up an older completed run
+    const preTriggerRuns = await fetchWorkflowRuns();
+    const preTriggerIds = new Set(preTriggerRuns.map(r => r.id));
+
+    // Trigger workflow
+    await triggerWorkflow();
+    console.log("✅ Trigger request successful. Waiting for workflow run to initialize on GitHub...");
+
+    // 4. Polling for the run to start and complete
+    let runId = null;
+    let runUrl = "";
+    const startTime = Date.now();
+    const timeout = 60000; // 1 minute timeout to find the run
+
+    while (!runId) {
+      if (Date.now() - startTime > timeout) {
+        throw new Error("Timeout waiting for GitHub Actions workflow run to appear.");
+      }
+      await new Promise(resolve => setTimeout(resolve, 5000));
+      process.stdout.write(".");
+
+      const activeRuns = await fetchWorkflowRuns();
+      // Look for a run that wasn't in the pre-trigger list and matches our target commit SHA
+      const newRun = activeRuns.find(run => !preTriggerIds.has(run.id) && run.headSha === headSha);
+      if (newRun) {
+        runId = newRun.id;
+        runUrl = newRun.url;
+        console.log(`\n\n📌 Found Active Run: ${runUrl}`);
+      }
+    }
+
+    // Now monitor the active run until completion
+    console.log("⏳ Monitoring build & deploy progress...");
+    let buildCompleted = false;
+    let pollInterval = 10000; // poll every 10s
+
+    while (!buildCompleted) {
+      await new Promise(resolve => setTimeout(resolve, pollInterval));
+      
+      const runs = await fetchWorkflowRuns();
+      const currentRun = runs.find(r => r.id === runId);
+
+      if (!currentRun) {
+        console.log("⚠️  Could not retrieve build status. Retrying...");
+        continue;
+      }
+
+      const status = currentRun.status;
+      const conclusion = currentRun.conclusion;
+
+      console.log(`   [${new Date().toLocaleTimeString()}] Status: ${status} | Conclusion: ${conclusion || "pending"}`);
+
+      if (status === "completed") {
+        buildCompleted = true;
+        if (conclusion === "success") {
+          console.log("\n🎉 GitHub Actions CI Build and Deploy Succeeded!");
+        } else {
+          throw new Error(`GitHub Actions workflow run failed with conclusion: ${conclusion}`);
+        }
+      }
+    }
+
+    // 5. Confirm the app is online afterwards
+    console.log("\n🌐 Verifying live site deployment...");
+    let domain = "playasontech.com";
+    const cnamePath = path.join(__dirname, "../public/CNAME");
+    
+    if (fs.existsSync(cnamePath)) {
+      const cnameContent = fs.readFileSync(cnamePath, "utf8").trim();
+      if (cnameContent) {
+        domain = cnameContent;
+      }
+    }
+
+    const targetUrl = `https://${domain}/`;
+    console.log(`Pinging live URL: ${targetUrl}`);
+
+    // Wait a couple of seconds for GitHub Pages DNS/files CDN cache invalidation
+    console.log("Waiting 5 seconds for CDN propagation...");
+    await new Promise(resolve => setTimeout(resolve, 5000));
+
+    try {
+      const res = await fetch(targetUrl, {
+        headers: { "User-Agent": "playas-on-tech-deploy-verifier" }
+      });
+      if (res.ok) {
+        console.log(`\n✨ SUCCESS! Website is ONLINE at ${targetUrl} (HTTP status: ${res.status})`);
+      } else {
+        console.log(`\n⚠️  Warning: Pinned site responded with HTTP ${res.status}. It might still be propagating. Please check it manually.`);
+      }
+    } catch (e) {
+      console.log(`\n⚠️  Warning: Failed to reach ${targetUrl}. It might still be propagating or experiencing a cold start. Please verify manually.`);
+    }
+
+  } catch (error) {
+    console.error(`\n❌ Deployment Failed: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
### Quick Info
---
This pull request transitions the site's deployment from local, manual builds to a secure, on-demand CI/CD pipeline integrated directly with GitHub Actions.

### Migrations? :-1:
---
None.

### What does this change?
---
- Adds an on-demand GitHub Actions deployment workflow (`deploy.yml`) utilizing `pnpm`, with environment variables injected securely via GitHub Secrets.
- Introduces `npm run deploy-ci` as a smart local CLI utility (`scripts/deploy-ci.js`) to trigger remote builds, stream real-time progress, and perform live site verification.
- Configures GitHub Environment tracking for `playasontech.com` deployments.
- Removes the old manual local deployment scripts (`predeploy`/`deploy`) and the `gh-pages` dependency to enforce the new pipeline.
- Updates documentation (`README.md` and `AGENTS.md`) to guide developers and future agents.

### Why are you changing that?
---
Relying on manual local builds required developers to keep environment variables (e.g. `NEXT_PUBLIC_WEB3FORMS_KEY`) on their machines and run build operations locally. This makes credential management difficult, is insecure, and can lead to build inconsistencies across machines. Moving to on-demand CI/CD secures the variables and standardizes the build process.

### How did you accomplish this change?
---
1. Created `.github/workflows/deploy.yml` with `workflow_dispatch` trigger, `pnpm` setup, static compilation, and `peaceiris/actions-gh-pages` deployment.
2. Built `scripts/deploy-ci.js` using native Node.js libraries to automate pushing, triggering the API, polling workflow status, and testing live domain resolution.
3. Removed `gh-pages` dependency and modified the scripts in `package.json`.
4. Documented the entire procedure in `README.md` and `AGENTS.md`.

### How do you manually test this?
---
1. Ensure the `NEXT_PUBLIC_WEB3FORMS_KEY` secret is configured in the repository's GitHub Settings.
2. Run `gh auth login` locally to authorize the CLI or set a `GITHUB_TOKEN` env var.
3. Run `npm run deploy-ci`.
4. Observe the terminal output: it will verify that remote tracking is up to date, trigger the CI build, poll progress in real time, and end by pinging `https://playasontech.com/` to verify it returns `200 OK`.

### Screenshots (If Apply)
N/A
