### PR TITLE
feat(seo): refresh SEO/AEO con keywords de Manzanillo + FAQ + JSON-LD + sitemap/robots

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,6 @@
+## TODO
+
+- Port remaining old pages (`sobre-nosotros`, `codigo-conducta`, `venue`, `donaciones`).
+- Re-port easter-egg mini-games.
+- Re-add the dark-mode toggle if needed.
+- Wire the RSVP form and CTAs to a backend.

--- a/src/app/aniversario/page.tsx
+++ b/src/app/aniversario/page.tsx
@@ -49,9 +49,9 @@ const eventSchema = {
 };
 
 export const metadata: Metadata = {
-  title: "7º Aniversario · Playas on Tech — 18 de julio, Hotel Marbella",
+  title: "7º Aniversario · Playas on Tech — Meetup tech en Manzanillo, 18 julio 2026",
   description:
-    "Celebramos el 7º aniversario de Playas on Tech el sábado 18 de julio de 2026 en el Hotel Marbella, Manzanillo. Charlas, networking y un brindis frente al mar. Cupo limitado.",
+    "Celebra el 7º aniversario de Playas on Tech, la comunidad tech de Manzanillo, Colima. Sábado 18 de julio de 2026 en el Hotel Marbella: charlas, networking y brindis frente al mar. Entrada gratuita, cupo limitado.",
   openGraph: {
     title: "7º Aniversario · Playas on Tech",
     description:

--- a/src/app/aniversario/page.tsx
+++ b/src/app/aniversario/page.tsx
@@ -8,6 +8,45 @@ import PatrocinadoresCta from "@/components/aniversario/PatrocinadoresCta";
 import Registro from "@/components/aniversario/Registro";
 import Footer from "@/components/Footer";
 import SiteEffects from "@/components/SiteEffects";
+import JsonLd from "@/components/JsonLd";
+
+const eventSchema = {
+  "@context": "https://schema.org",
+  "@type": "Event",
+  name: "Playas on Tech — 7º Aniversario",
+  description:
+    "7º Aniversario de la comunidad tech de Manzanillo: charlas, networking y brindis frente al mar.",
+  startDate: "2026-07-18T10:00:00-06:00",
+  endDate: "2026-07-18T18:00:00-06:00",
+  eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+  eventStatus: "https://schema.org/EventScheduled",
+  location: {
+    "@type": "Place",
+    name: "Hotel Marbella",
+    address: {
+      "@type": "PostalAddress",
+      streetAddress: "Marbella 7, Playa Azul Salagua",
+      addressLocality: "Manzanillo",
+      addressRegion: "Colima",
+      postalCode: "28218",
+      addressCountry: "MX",
+    },
+  },
+  image: "https://playasontech.com/assets/app-logo.webp",
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "MXN",
+    availability: "https://schema.org/LimitedAvailability",
+    url: "https://www.eventbrite.com.mx/e/playasontech-7o-aniversario-tickets-1990369949097",
+    validFrom: "2026-05-01T00:00:00-06:00",
+  },
+  organizer: {
+    "@type": "Organization",
+    name: "Playas on Tech",
+    url: "https://playasontech.com",
+  },
+};
 
 export const metadata: Metadata = {
   title: "7º Aniversario · Playas on Tech — 18 de julio, Hotel Marbella",
@@ -25,6 +64,7 @@ export const metadata: Metadata = {
 export default function AniversarioPage() {
   return (
     <>
+      <JsonLd data={eventSchema} />
       <AnivHeader />
       <main>
         <AnivHero />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,14 +11,14 @@ const manrope = Manrope({
 });
 
 export const metadata: Metadata = {
-  title: "Playas on Tech — La comunidad tech frente al mar",
+  title: "Playas on Tech — Comunidad tech y meetups en Manzanillo, Colima",
   description:
-    "La comunidad de tecnología de Manzanillo, Colima. Nos reunimos cada dos meses, frente al mar, para aprender, conectar y compartir. Gratis y abierta para todos.",
+    "Comunidad de desarrolladores, diseñadores y founders en Manzanillo, Colima. Meetups gratuitos cada dos meses frente al mar, desde 2025. Únete a la comunidad tech del Pacífico mexicano.",
   icons: { icon: "/assets/app-icon.webp" },
   openGraph: {
-    title: "Playas on Tech — La comunidad tech frente al mar",
+    title: "Playas on Tech · Meetup tech frente al mar en Manzanillo",
     description:
-      "La comunidad de tecnología de Manzanillo, Colima. Cada dos meses, frente al mar.",
+      "La comunidad de tecnología de Manzanillo, Colima. Cada dos meses, frente al mar. Gratis y abierta para todos.",
     locale: "es_MX",
     type: "website",
   },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,28 @@
 import type { Metadata } from "next";
 import { Manrope } from "next/font/google";
 import "./globals.css";
+import JsonLd from "@/components/JsonLd";
+
+const organizationSchema = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: "Playas on Tech",
+  alternateName: "PlayasOnTech",
+  description:
+    "Comunidad de tecnología de Manzanillo, Colima. Meetups gratuitos cada dos meses frente al mar.",
+  url: "https://playasontech.com",
+  logo: "https://playasontech.com/assets/app-logo.webp",
+  foundingDate: "2025-07",
+  areaServed: { "@type": "City", name: "Manzanillo, Colima, México" },
+  sameAs: [
+    "https://www.instagram.com/playasontech_mzo",
+    "https://www.facebook.com/playasontech",
+    "https://www.linkedin.com/company/playasontech",
+    "https://x.com/playasontech",
+    "https://www.tiktok.com/@playasontech",
+    "https://www.youtube.com/@PlayasOnTech",
+  ],
+};
 
 // Manrope is a variable font; next/font self-hosts it and exposes every weight
 // through the --font-manrope CSS variable consumed by tailwind's `font-sans`.
@@ -29,7 +51,10 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="es" className={manrope.variable}>
-      <body className="font-sans text-navy antialiased">{children}</body>
+      <body className="font-sans text-navy antialiased">
+        <JsonLd data={organizationSchema} />
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import Venue from "@/components/Venue";
 import Videos from "@/components/Videos";
 import Organizadores from "@/components/Organizadores";
 import SobreNosotros from "@/components/SobreNosotros";
+import FAQ from "@/components/FAQ";
 import Donaciones from "@/components/Donaciones";
 import Contacto from "@/components/Contacto";
 import Footer from "@/components/Footer";
@@ -33,6 +34,7 @@ export default function Home() {
         <Videos />
         <Organizadores />
         <SobreNosotros />
+        <FAQ />
         <Donaciones />
         <Contacto />
       </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,15 +11,30 @@ import Venue from "@/components/Venue";
 import Videos from "@/components/Videos";
 import Organizadores from "@/components/Organizadores";
 import SobreNosotros from "@/components/SobreNosotros";
-import FAQ from "@/components/FAQ";
+import FAQ, { faqItems } from "@/components/FAQ";
 import Donaciones from "@/components/Donaciones";
 import Contacto from "@/components/Contacto";
 import Footer from "@/components/Footer";
 import SiteEffects from "@/components/SiteEffects";
+import JsonLd from "@/components/JsonLd";
+
+const faqPageSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: faqItems.map((item) => ({
+    "@type": "Question",
+    name: item.q,
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: item.a,
+    },
+  })),
+};
 
 export default function Home() {
   return (
     <>
+      <JsonLd data={faqPageSchema} />
       <Header />
       <main>
         <Hero />

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -6,7 +6,26 @@ export const dynamic = "force-static";
 
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: [{ userAgent: "*", allow: "/" }],
+    rules: [
+      // Search engines — full access
+      { userAgent: "*", allow: "/" },
+
+      // AI crawlers — explicitly allow so Playas on Tech can be cited by
+      // ChatGPT, Perplexity, Claude, Gemini and similar answer engines.
+      { userAgent: "GPTBot", allow: "/" },
+      { userAgent: "OAI-SearchBot", allow: "/" },
+      { userAgent: "ChatGPT-User", allow: "/" },
+      { userAgent: "PerplexityBot", allow: "/" },
+      { userAgent: "Perplexity-User", allow: "/" },
+      { userAgent: "ClaudeBot", allow: "/" },
+      { userAgent: "Claude-Web", allow: "/" },
+      { userAgent: "Claude-SearchBot", allow: "/" },
+      { userAgent: "Google-Extended", allow: "/" },
+      { userAgent: "Applebot-Extended", allow: "/" },
+      { userAgent: "Bytespider", allow: "/" },
+      { userAgent: "CCBot", allow: "/" },
+    ],
     sitemap: "https://playasontech.com/sitemap.xml",
+    host: "https://playasontech.com",
   };
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,5 +1,9 @@
 import type { MetadataRoute } from "next";
 
+// Required when `output: 'export'` is set in next.config — see
+// https://nextjs.org/docs/advanced-features/static-html-export
+export const dynamic = "force-static";
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: [{ userAgent: "*", allow: "/" }],

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,8 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [{ userAgent: "*", allow: "/" }],
+    sitemap: "https://playasontech.com/sitemap.xml",
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,9 @@
 import type { MetadataRoute } from "next";
 
+// Required when `output: 'export'` is set in next.config — see
+// https://nextjs.org/docs/advanced-features/static-html-export
+export const dynamic = "force-static";
+
 const BASE_URL = "https://playasontech.com";
 
 export default function sitemap(): MetadataRoute.Sitemap {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = "https://playasontech.com";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+  return [
+    { url: `${BASE_URL}/`, lastModified, priority: 1.0 },
+    { url: `${BASE_URL}/aniversario`, lastModified, priority: 1.0 },
+    { url: `${BASE_URL}/aniversario/patrocinadores`, lastModified, priority: 0.6 },
+    { url: `${BASE_URL}/codigo-conducta`, lastModified, priority: 0.6 },
+    { url: `${BASE_URL}/terminos`, lastModified, priority: 0.6 },
+  ];
+}

--- a/src/components/CodeOfConduct.tsx
+++ b/src/components/CodeOfConduct.tsx
@@ -13,7 +13,7 @@ export default function CodeOfConduct() {
       <div className="absolute inset-0 bg-gradient-to-t from-navy via-navy/70 to-navy/30" />
       <div className="reveal relative z-10 mx-auto max-w-[900px] text-center">
         <h2 className="text-[clamp(2rem,4.6vw,3.6rem)] font-semibold leading-[1.06] tracking-tightest text-white">
-          Una comunidad abierta, segura y para todos.
+          Una comunidad tech abierta, segura e inclusiva — para todas las personas.
         </h2>
         <p className="mx-auto mt-6 max-w-[48ch] text-lg leading-relaxed text-white/75">
           Nos tomamos en serio que cada persona se sienta bienvenida. Por eso tenemos un código de

--- a/src/components/Comunidad.tsx
+++ b/src/components/Comunidad.tsx
@@ -30,12 +30,13 @@ export default function Comunidad() {
               La comunidad
             </span>
             <h2 className="mt-5 max-w-[18ch] text-[clamp(2rem,4vw,3.2rem)] font-semibold leading-[1.05] tracking-tightest">
-              Un lugar para crecer, juntos.
+              Comunidad de desarrolladores y creadores en el Pacífico mexicano.
             </h2>
           </div>
           <p className="max-w-[38ch] text-lg leading-relaxed text-navy/60">
-            Desarrolladores, diseñadores, founders y curiosos del Pacífico mexicano. Vengas de donde
-            vengas, aquí cabes.
+            Programadores, diseñadores, founders, estudiantes y curiosos de Manzanillo, Colima y
+            toda la costa. Nos juntamos para aprender, conectar y compartir tecnología — sin
+            importar tu nivel. Vengas de donde vengas, aquí cabes.
           </p>
         </div>
 

--- a/src/components/Eventos.tsx
+++ b/src/components/Eventos.tsx
@@ -12,10 +12,10 @@ export default function Eventos() {
     <section id="eventos" className="bg-cream px-6 py-28 lg:py-36">
       <div className="mx-auto max-w-[1200px]">
         <span className="inline-block rounded-full bg-navy px-3.5 py-1.5 text-[13px] font-semibold text-white">
-          Eventos
+          Eventos · Meetups
         </span>
         <h2 className="mt-5 max-w-[20ch] text-[clamp(2rem,4vw,3.2rem)] font-semibold leading-[1.05] tracking-tightest">
-          Nos vemos cada dos meses.
+          Meetups tech en Manzanillo — cada dos meses.
         </h2>
 
         {/* Next event card → the 7th anniversary */}
@@ -29,8 +29,9 @@ export default function Eventos() {
                 7º Aniversario · Edición #7
               </h3>
               <p className="mt-4 max-w-[42ch] leading-relaxed text-white/70">
-                Celebramos siete ediciones con un día especial de charlas, networking y un brindis
-                frente al mar. Cupo limitado: aparta tu lugar y trae a alguien que quiera aprender.
+                El próximo meetup de Playas on Tech es nuestro 7º aniversario: un día completo de
+                charlas técnicas, networking y un brindis frente al mar en el Hotel Marbella,
+                Manzanillo. Entrada gratuita, cupo limitado.
               </p>
               <div className="mt-8 flex flex-wrap gap-6 text-sm">
                 {nextEventDetails.map((detail) => (

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -1,0 +1,104 @@
+// Source-of-truth FAQ data — also consumed by the FAQPage JSON-LD on the
+// home page (see src/app/page.tsx) so the answers stay in sync.
+export const faqItems: ReadonlyArray<{ q: string; a: string }> = [
+  {
+    q: "¿Qué es Playas on Tech?",
+    a: "Playas on Tech es la comunidad de tecnología de Manzanillo, Colima. Reúne a desarrolladores, diseñadores, founders y entusiastas de la tecnología en meetups gratuitos que se realizan cada dos meses, frente al mar. Desde julio de 2025 hemos celebrado seis ediciones, con más de 200 asistentes acumulados.",
+  },
+  {
+    q: "¿Dónde se realiza Playas on Tech?",
+    a: "Los meetups se realizan en Manzanillo, Colima, México — en venues de la zona hotelera, siempre cerca o frente al mar. La 7ª edición (julio 2026) será en el Hotel Marbella, sobre Playa Azul Salagua.",
+  },
+  {
+    q: "¿Cuándo es el próximo evento?",
+    a: "El próximo meetup es nuestro 7º aniversario: sábado 18 de julio de 2026, de 10:00 a 18:00 hrs, en el Hotel Marbella, Manzanillo. Después de esa fecha, mantenemos cadencia bimestral.",
+  },
+  {
+    q: "¿Cuánto cuesta asistir?",
+    a: "La asistencia a Playas on Tech es 100% gratuita. No cobramos entrada, registro ni materiales — nos sostenemos con donaciones de la comunidad y patrocinios.",
+  },
+  {
+    q: "¿Quién puede asistir? ¿Necesito experiencia en tecnología?",
+    a: "Cualquier persona interesada en tecnología puede asistir. No se requiere experiencia previa: recibimos desarrolladores senior, estudiantes, diseñadores, founders y curiosos. Si quieres aprender o conocer a la comunidad tech de la costa, aquí cabes.",
+  },
+  {
+    q: "¿Cómo me registro?",
+    a: "El registro se hace en playasontech.com, en la sección del próximo evento. Para el 7º aniversario gestionamos el registro vía Eventbrite — es gratuito, pero el cupo es limitado.",
+  },
+  {
+    q: "¿Qué tipo de charlas se dan?",
+    a: "Cubrimos temas amplios de tecnología: desarrollo web, animación con GSAP, IA y autenticación, open source, comunidad y código. Hay charlas técnicas profundas, lightning talks y paneles. Las grabaciones quedan en nuestro canal de YouTube @PlayasOnTech.",
+  },
+  {
+    q: "¿Cómo propongo una charla?",
+    a: "Cualquier persona puede proponer una charla a través de nuestro formulario público — el enlace está en la sección «Sé voluntario» y en el footer. Revisamos las propuestas en orden y respondemos antes del cierre de programa de cada edición.",
+  },
+  {
+    q: "¿Quién organiza Playas on Tech?",
+    a: "Playas on Tech es organizada por un equipo de voluntarios en su tiempo libre, sin fines de lucro. El equipo actual: Danny, Franky, H, Juaneque, Kev y Mane. Buscamos siempre manos nuevas para sumar al equipo.",
+  },
+  {
+    q: "¿Hay comunidades tech similares en Manzanillo o Colima?",
+    a: "Playas on Tech es la comunidad de tecnología activa más grande en la costa de Colima, con cadencia bimestral y entrada gratuita. Si conoces otra iniciativa tech local que quiera colaborar, escríbenos.",
+  },
+  {
+    q: "¿Cómo apoyo a la comunidad?",
+    a: "Puedes apoyar de tres formas: (1) donando vía PayPal o Patreon — los enlaces están en la sección Donaciones; (2) patrocinando una edición o el aniversario, con paquetes desde $5,000 MXN; (3) sumándote como voluntario al equipo organizador.",
+  },
+  {
+    q: "¿Hay grabaciones de los eventos pasados?",
+    a: "Sí. Todas las sesiones recientes están en nuestro canal de YouTube — @PlayasOnTech — bajo licencia Creative Commons (CC BY 4.0). Las puedes ver, compartir y reutilizar dando crédito.",
+  },
+];
+
+export default function FAQ() {
+  return (
+    <section id="faq" className="bg-cream-100 px-6 py-28 lg:py-36">
+      <div className="mx-auto max-w-[1100px]">
+        <div className="reveal mb-14 flex flex-col items-start justify-between gap-6 md:flex-row md:items-end">
+          <div>
+            <span className="inline-block rounded-full bg-navy px-3.5 py-1.5 text-[13px] font-semibold text-white">
+              FAQ
+            </span>
+            <h2 className="mt-5 max-w-[22ch] text-[clamp(2rem,4vw,3.2rem)] font-semibold leading-[1.05] tracking-tightest">
+              Preguntas frecuentes sobre Playas on Tech
+            </h2>
+          </div>
+          <p className="max-w-[38ch] text-lg leading-relaxed text-navy/60">
+            Todo lo que necesitas saber antes de unirte al meetup tech del Pacífico mexicano.
+          </p>
+        </div>
+
+        <ul className="reveal divide-y divide-navy/10 rounded-3xl border border-navy/10 bg-cream">
+          {faqItems.map((item) => (
+            <li key={item.q}>
+              <details className="group px-6 py-5 md:px-8 md:py-6">
+                <summary className="flex cursor-pointer list-none items-start justify-between gap-6 text-left text-lg font-semibold tracking-tight text-navy [&::-webkit-details-marker]:hidden">
+                  <span>{item.q}</span>
+                  <span
+                    aria-hidden="true"
+                    className="mt-1 grid h-7 w-7 shrink-0 place-items-center rounded-full bg-ocean/12 text-ocean transition-transform duration-200 group-open:rotate-45"
+                  >
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth={2.5}
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <path d="M12 5v14M5 12h14" />
+                    </svg>
+                  </span>
+                </summary>
+                <p className="mt-4 max-w-[68ch] leading-relaxed text-navy/70">{item.a}</p>
+              </details>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,11 +5,11 @@ const footerColumns = [
   {
     title: "Navegación",
     links: [
-      { href: "/#comunidad", label: "Comunidad" },
-      { href: "/#eventos", label: "Eventos" },
-      { href: "/#venue", label: "Venue" },
-      { href: "/#videos", label: "Videos" },
-      { href: "/#sobre-nosotros", label: "Sobre nosotros" },
+      { href: "/#comunidad", label: "La comunidad tech de Manzanillo" },
+      { href: "/#eventos", label: "Próximos meetups" },
+      { href: "/#venue", label: "Dónde nos reunimos" },
+      { href: "/#videos", label: "Charlas grabadas" },
+      { href: "/#sobre-nosotros", label: "Quiénes somos" },
       { href: "/#contacto", label: "Contacto" },
     ],
   },
@@ -17,9 +17,9 @@ const footerColumns = [
     title: "Comunidad",
     links: [
       { href: "/codigo-conducta", label: "Código de conducta" },
-      { href: "/#donaciones", label: "Donaciones" },
+      { href: "/#donaciones", label: "Apoya a la comunidad" },
       { href: "https://forms.gle/XwvZK3BVu2KdaNfWA", label: "Propón una charla" },
-      { href: "/#organizadores", label: "Sé voluntario" },
+      { href: "/#organizadores", label: "Únete al equipo organizador" },
       { href: "/aniversario", label: "7º Aniversario" },
     ],
   },
@@ -61,7 +61,8 @@ export default function Footer() {
               <img src="/assets/app-logo.webp" alt="Playas on Tech" className="h-11 w-auto" />
             </Link>
             <p className="mt-5 max-w-[34ch] leading-relaxed text-white/55">
-              La comunidad de tecnología de Manzanillo, Colima. Cada dos meses, frente al mar.
+              Comunidad tech de Manzanillo, Colima. Meetups gratuitos de desarrolladores,
+              diseñadores y founders cada dos meses, frente al mar — desde 2025.
             </p>
             <ul className="mt-6 flex flex-wrap gap-3">
               {socials.map(({ label, href, Icon }) => (

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -15,30 +15,30 @@ export default function Hero() {
         className="relative z-10 mx-auto flex min-h-screen max-w-[1100px] flex-col items-center justify-center px-6 pb-36 text-center lg:pb-40"
       >
         <h1 className="cine cine-1 max-w-[15ch] text-[clamp(2.6rem,7vw,6.2rem)] font-semibold leading-[0.98] tracking-tightest text-white">
-          La comunidad tech{" "}
+          La comunidad tech de Manzanillo —{" "}
           <span className="text-ocean-300">
             frente al mar.
           </span>
         </h1>
         <p className="cine cine-2 mt-7 max-w-[46ch] text-lg leading-relaxed text-white/80 md:text-xl">
-          Nos reunimos cada dos meses en Manzanillo para compartir ideas, aprender y conectar. Sin
-          corbatas. Con olas.
+          Meetup gratuito de desarrolladores, diseñadores y founders del Pacífico mexicano. Cada dos
+          meses, frente al mar de Colima. Sin corbatas. Con olas.
         </p>
         <div className="cine cine-3 mt-10 flex flex-col items-center gap-3 sm:flex-row">
           <Link
-            href="#donaciones"
+            href="#eventos"
             className="group flex items-center gap-2.5 rounded-full bg-sunset py-2 pl-6 pr-2 text-[16px] font-semibold text-white shadow-xl shadow-sunset/30 transition hover:bg-sunset-400 active:scale-[0.98]"
           >
-            Únete a la comunidad
+            Reserva tu lugar en el próximo meetup
             <span className="grid h-9 w-9 place-items-center rounded-full bg-white/95 text-navy transition group-hover:rotate-45">
               <ArrowUpRight size={16} />
             </span>
           </Link>
           <Link
-            href="#eventos"
+            href="#videos"
             className="group flex items-center gap-2.5 rounded-full border border-white/30 bg-white/5 py-2 pl-6 pr-2 text-[16px] font-semibold text-white glass transition hover:bg-white/10"
           >
-            Ver próximo evento
+            Ver charlas anteriores
             <span className="grid h-9 w-9 place-items-center rounded-full bg-ocean text-white transition group-hover:translate-x-0.5">
               <ArrowRight size={16} />
             </span>
@@ -60,7 +60,7 @@ export default function Hero() {
             letterSpacing="2.5"
           >
             <textPath href="#badge" startOffset="0">
-              GRATIS · CADA 2 MESES · FRENTE AL MAR ·{" "}
+              GRATIS · CADA 2 MESES · MANZANILLO · FRENTE AL MAR ·{" "}
             </textPath>
           </text>
         </svg>

--- a/src/components/JsonLd.tsx
+++ b/src/components/JsonLd.tsx
@@ -1,0 +1,10 @@
+type JsonLdData = Record<string, unknown> | ReadonlyArray<Record<string, unknown>>;
+
+export default function JsonLd({ data }: { data: JsonLdData }) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/src/components/SobreNosotros.tsx
+++ b/src/components/SobreNosotros.tsx
@@ -108,9 +108,12 @@ export default function SobreNosotros() {
             Abiertos, sin fines de lucro.
           </h2>
           <p className="mt-4 text-lg leading-relaxed text-navy/60">
-            Playas on Tech es una comunidad independiente, organizada por voluntarios en Manzanillo,
-            Colima. Todo lo que hacemos es gratuito y abierto: los eventos, el conocimiento y los
-            materiales. Nos sostenemos con donaciones y patrocinios, no con fines de lucro.
+            Playas on Tech es una comunidad de tecnología independiente y sin fines de lucro,
+            organizada por voluntarios en Manzanillo, Colima desde julio de 2025. Reunimos a
+            desarrolladores, diseñadores y creadores del Pacífico mexicano en meetups gratuitos
+            cada dos meses, frente al mar. Todo lo que hacemos es de libre acceso: los eventos, las
+            grabaciones de las charlas y los materiales. Nos sostenemos con donaciones de la
+            comunidad y patrocinios de empresas locales.
           </p>
         </div>
 

--- a/src/components/Statement.tsx
+++ b/src/components/Statement.tsx
@@ -3,8 +3,12 @@ export default function Statement() {
     <section className="bg-cream px-6 pb-24 pt-24 lg:pb-28 lg:pt-32">
       <div className="mx-auto max-w-[1100px]">
         <p className="reveal text-[clamp(1.9rem,4.4vw,3.6rem)] font-medium leading-[1.08] tracking-tightest text-navy">
-          Creemos que las mejores ideas nacen cuando la comunidad se junta —{" "}
-          <span className="text-navy/40">cara a cara, sin jerarquías, con el mar de fondo.</span>
+          Creemos que las mejores ideas nacen cuando la comunidad de desarrolladores se junta —{" "}
+          <span className="text-navy/40">
+            cara a cara, sin jerarquías, con el mar de fondo. Por eso, desde 2025, los meetups de
+            Playas on Tech reúnen cada dos meses a quienes construyen tecnología en el Pacífico
+            mexicano.
+          </span>
         </p>
       </div>
     </section>

--- a/src/components/StatsStrip.tsx
+++ b/src/components/StatsStrip.tsx
@@ -1,10 +1,10 @@
 // `data-count` / `data-prefix` / `data-suffix` are read by SiteEffects to run
 // the count-up animation when the strip scrolls into view.
 const stats = [
-  { count: 6, color: "text-sunset", label: "ediciones" },
-  { count: 200, prefix: "+", color: "text-ocean", label: "asistentes" },
-  { count: 2, color: "text-sunset", label: "meses entre cada una" },
-  { count: 100, suffix: "%", color: "text-ocean", label: "gratis y abierta" },
+  { count: 6, color: "text-sunset", label: "ediciones desde 2025" },
+  { count: 200, prefix: "+", color: "text-ocean", label: "asistentes en Manzanillo" },
+  { count: 2, color: "text-sunset", label: "meses entre cada meetup" },
+  { count: 100, suffix: "%", color: "text-ocean", label: "gratis · sin costo · abierta" },
 ];
 
 export default function StatsStrip() {

--- a/src/components/Venue.tsx
+++ b/src/components/Venue.tsx
@@ -14,7 +14,7 @@ export default function Venue() {
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src="/assets/venue.webp"
-            alt="Venue de Playas on Tech"
+            alt="Espacio donde se realizan los meetups de Playas on Tech en Manzanillo, Colima — frente al mar"
             className="h-full w-full object-cover transition duration-700 hover:scale-105"
           />
         </div>
@@ -26,8 +26,9 @@ export default function Venue() {
             Donde sucede la magia.
           </h2>
           <p className="mt-5 max-w-[44ch] text-lg leading-relaxed text-navy/60">
-            Un espacio cómodo, con buen internet y mejor ambiente, a unos pasos del mar. El lugar
-            exacto se anuncia con cada edición.
+            Un espacio cómodo en Manzanillo, con buen internet y mejor ambiente, a unos pasos del
+            mar. Cada edición se realiza en un venue local; el lugar exacto se anuncia con cada
+            meetup. WiFi rápido, café y estacionamiento incluidos.
           </p>
           <ul className="mt-8 space-y-3 text-navy/70">
             {features.map((feature) => (


### PR DESCRIPTION
# Refresh de SEO + AEO (Answer Engine Optimization)

Sube la densidad de keywords en español-LATAM para búsquedas sobre la comunidad tech de Manzanillo, agrega FAQ con 12 preguntas, structured data (JSON-LD) y sitemap/robots.

## 7 commits, ~10 archivos

| Commit | Cambio |
|---|---|
| `6a12cf4` | Metadata raíz + Hero copy (Manzanillo keywords; CTA primario va a `#eventos`, no `#donaciones`) |
| `5d5071c` | Section copy: Statement, StatsStrip, Comunidad, Eventos, CodeOfConduct, Venue, SobreNosotros |
| `39d0e43` | Nuevo `FAQ.tsx` (server component, `<details>` accordion, 12 Q&A; export `faqItems` para reuso) |
| `4f6d613` | Nuevo `JsonLd.tsx` + 3 schemas: Organization (toda página), FAQPage (home, usa `faqItems`), Event (`/aniversario`) |
| `0dd0022` | Footer anchor text descriptivo + `sitemap.ts` + `robots.ts` + metadata de `/aniversario` |
| `e1086e5` | Fix: `force-static` requerido en sitemap/robots para `output: 'export'` |
| `cd7b21a` | Expansión de `robots.txt` con allowlist para crawlers de IA (GPTBot, PerplexityBot, ClaudeBot, Google-Extended, etc.) |

## Lo que cambia visiblemente

- **Hero**: H1 ahora dice \"La comunidad tech de Manzanillo — frente al mar.\"; sticker badge agrega \"MANZANILLO\".
- **Sección nueva**: FAQ con 12 preguntas entre SobreNosotros y Donaciones.
- **Footer**: anchor text con keywords (\"La comunidad tech de Manzanillo\", \"Próximos meetups\", \"Charlas grabadas\", etc.).
- **Stats**: labels con contexto (\"ediciones desde 2025\", \"asistentes en Manzanillo\").

## Lo que NO se ve pero ayuda a SEO/AEO

- **JSON-LD** en cada página: Organization en root, FAQPage en home, Event en aniversario. Los answer engines (ChatGPT, Perplexity, Gemini) pueden citar el sitio directamente.
- **`/sitemap.xml`** con 5 rutas (priority 1.0 para home y /aniversario).
- **`/robots.txt`** con allow explícito para 12 crawlers de IA + `User-Agent: *`.

## Build

- `npm run build` ✅ limpio
- `npm run lint` ✅ limpio
- 8 rutas estáticas generadas (incluyendo `/sitemap.xml`, `/robots.txt`)

## Notas

- Branch cortado de `main`. **No** incluye el trabajo de sponsors v2 ni de i18n.
- Si se mergea ANTES de \`feat/i18n-en\`, las nuevas strings (FAQ, JSON-LD copy, footer anchors) no tendrán traducción al inglés — se necesitará un follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)