### PR TITLE
feat(sponsors): 4 paquetes (Silver/Gold/Platinum/Diamond) con USD, keynote, attendee-list, rifa

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,6 @@
+## TODO
+
+- Port remaining old pages (`sobre-nosotros`, `codigo-conducta`, `venue`, `donaciones`).
+- Re-port easter-egg mini-games.
+- Re-add the dark-mode toggle if needed.
+- Wire the RSVP form and CTAs to a backend.

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -131,3 +131,19 @@ export function MapPin(props: IconProps) {
     </StrokeIcon>
   );
 }
+
+export function Users(props: IconProps) {
+  return (
+    <StrokeIcon {...props}>
+      <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2M9 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
+    </StrokeIcon>
+  );
+}
+
+export function Gift(props: IconProps) {
+  return (
+    <StrokeIcon {...props}>
+      <path d="M20 12v10H4V12M2 7h20v5H2zM12 22V7M12 7H7.5a2.5 2.5 0 0 1 0-5C11 2 12 7 12 7zM12 7h4.5a2.5 2.5 0 0 0 0-5C13 2 12 7 12 7z" />
+    </StrokeIcon>
+  );
+}

--- a/src/components/aniversario/Patrocinadores.tsx
+++ b/src/components/aniversario/Patrocinadores.tsx
@@ -1,16 +1,20 @@
 import Link from "next/link";
-import { ArrowUpRight, Check } from "../Icons";
-
-// Sponsorship inquiries go through the community's Instagram DMs.
-const CONTACT_URL = "https://www.instagram.com/playasontech_mzo";
+import { ArrowUpRight, Check, Users, Gift } from "../Icons";
+import { TICKET } from "./event";
 
 type Tier = {
   name: string;
   accent: string;
   priceMXN: number;
+  priceUSD: number;
+  seats: string;
   tagline: string;
-  featured?: boolean;
   benefits: string[];
+  featured?: boolean;
+  headline?: boolean;
+  keynote?: boolean;
+  attendeeList?: "Standard" | "Plus" | "Premium";
+  ctaLabel?: string;
 };
 
 const tiers: Tier[] = [
@@ -18,39 +22,90 @@ const tiers: Tier[] = [
     name: "Silver",
     accent: "text-navy/70",
     priceMXN: 5000,
+    priceUSD: 300,
+    seats: "Sin límite de cupos",
     tagline: "Apoya a la comunidad y date a conocer.",
     benefits: [
-      "Logo en el sitio del evento",
-      "Mención en redes sociales",
-      "2 cortesías de acceso",
+      "Logo en el sitio del evento (sección Silver)",
+      "Mención agrupada en redes sociales",
+      "Logo en pantalla durante intermedios",
+      "Mención en agradecimientos de cierre",
+      "Sticker físico en welcome kit",
+      "Atribución en YouTube (logo en descripción del recap)",
+      "Mención en los siguientes 3 newsletters bimestrales",
+      "2 boletos cortesía (úsalos para tu equipo o ríflalos en redes en nombre de tu marca)",
+      "Reporte post-evento a 30 días",
     ],
   },
   {
     name: "Gold",
     accent: "text-sunset",
     priceMXN: 10000,
-    tagline: "Presencia destacada antes y durante la noche.",
+    priceUSD: 600,
+    seats: "Hasta 4 cupos por edición",
+    tagline: "Presencia destacada en el venue y la noche.",
     featured: true,
+    attendeeList: "Standard",
     benefits: [
       "Todo lo de Silver",
-      "Logo en pantalla durante el evento",
       "Mesa o stand en el venue",
-      "5 cortesías de acceso",
-      "Mención desde el escenario",
+      "Logo en pantalla recurrente durante el evento",
+      "Mención individual desde el escenario",
+      "Materiales en welcome kit (pieza física + sticker)",
+      "Lightning sponsor moment (2 min onstage)",
+      "Mención en mail post-evento a asistentes",
+      "Lista de asistentes (Standard) — opt-ins con datos de contacto, entrega post-evento (día +3). Para marketing y/u ofertas laborales.",
+      "4 boletos cortesía (úsalos para tu equipo o ríflalos en redes)",
     ],
   },
   {
     name: "Platinum",
     accent: "text-ocean",
     priceMXN: 20000,
-    tagline: "Patrocinador principal del 7º aniversario.",
+    priceUSD: 1200,
+    seats: "Hasta 2 cupos por edición",
+    tagline: "Patrocinador principal — protagonista en escenario y venue.",
+    keynote: true,
+    attendeeList: "Plus",
     benefits: [
       "Todo lo de Gold",
-      "“Presentado por” — naming del evento",
-      "Espacio para keynote o demo (10 min)",
-      "Logo en todo el material y el video",
-      "10 cortesías + acceso VIP al brindis",
-      "Contenido dedicado posterior al evento",
+      "Keynote técnico de 45 min + 15 min Q&A (slot principal de agenda)",
+      "Stand premium en venue",
+      "Logo en intro/outro del video oficial del evento",
+      "Post dedicado en redes pre-evento",
+      "Mención destacada en blog/recap post-evento",
+      "Lista de asistentes (Plus) — entrega 7 días pre-evento + segmentación por rol/seniority/industria. Para marketing y/u ofertas laborales.",
+      "Coffee Break by [Marca] (opcional)",
+      "6 boletos cortesía",
+    ],
+  },
+  {
+    name: "Diamond",
+    accent: "text-[#5B3FA8]",
+    priceMXN: 40000,
+    priceUSD: 2400,
+    seats: "1 cupo · único por edición",
+    tagline: "El 7º Aniversario, presentado por ti.",
+    headline: true,
+    keynote: true,
+    attendeeList: "Premium",
+    ctaLabel: "Conversemos sobre Diamond",
+    benefits: [
+      "Naming rights — «Presentado por [Marca]»",
+      "Welcome desde el escenario (5 min)",
+      "Keynote de apertura — 45 min + 15 min Q&A",
+      "Co-branded lockup en TODOS los assets del evento",
+      "Recap video del evento, sponsoreado",
+      "Playera oficial co-branded",
+      "Espacio de activación premium",
+      "Mesa redonda o panel co-creado",
+      "Exclusividad de categoría",
+      "Contenido dedicado post-evento (blog + podcast + redes)",
+      "Lista de asistentes (Premium) — entrega 14 días pre-evento + segmentación + 3 intros directas a asistentes específicos. Para marketing y/u ofertas laborales.",
+      "10 boletos cortesía (máximo del paquete · úsalos para tu equipo o ríflalos en redes)",
+      "Acknowledgment en kits de prensa",
+      "Reunión de planeación con el equipo organizador",
+      "Right of first refusal — próxima edición",
     ],
   },
 ];
@@ -61,6 +116,33 @@ const mediaPartnerPerks = [
   "Acceso de prensa",
   "Logo como media partner",
 ];
+
+const ATTENDEE_LIST_PILL: Record<NonNullable<Tier["attendeeList"]>, string> = {
+  Standard: "bg-sunset/10 text-sunset",
+  Plus: "bg-ocean/15 text-ocean",
+  Premium: "bg-[#5B3FA8]/15 text-[#5B3FA8]",
+};
+
+// `headline` takes precedence over `featured` when both are set.
+function cardClasses(tier: Tier) {
+  if (tier.headline) {
+    return "border-[#5B3FA8]/40 bg-cream shadow-2xl shadow-[#5B3FA8]/10";
+  }
+  if (tier.featured) {
+    return "border-sunset/40 bg-cream shadow-2xl shadow-sunset/10 lg:-mt-4 lg:pb-12";
+  }
+  return "border-navy/10 bg-cream";
+}
+
+function ctaClasses(tier: Tier) {
+  if (tier.headline) {
+    return "bg-[#5B3FA8] text-white hover:bg-[#4a3290] active:scale-[0.98]";
+  }
+  if (tier.featured) {
+    return "bg-sunset text-white hover:bg-sunset-400 active:scale-[0.98]";
+  }
+  return "border border-navy/15 text-navy hover:bg-navy hover:text-white";
+}
 
 export default function Patrocinadores({ withHeader = true }: { withHeader?: boolean }) {
   return (
@@ -81,29 +163,57 @@ export default function Patrocinadores({ withHeader = true }: { withHeader?: boo
           </div>
         )}
 
-        <div className="grid gap-5 lg:grid-cols-3 pb-28">
+        <div className="grid gap-5 pb-16 md:grid-cols-2 lg:grid-cols-4">
           {tiers.map((tier) => (
             <div
               key={tier.name}
-              className={`reveal relative rounded-3xl border p-8 flex flex-col h-full ${
-                tier.featured
-                  ? "border-sunset/40 bg-cream shadow-2xl shadow-sunset/10 lg:-mt-4 lg:pb-12"
-                  : "border-navy/10 bg-cream"
-              }`}
+              className={`reveal relative flex h-full flex-col rounded-3xl border p-8 ${cardClasses(tier)}`}
             >
-              {tier.featured && (
+              {tier.headline ? (
+                <span className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-[#5B3FA8] px-3.5 py-1 text-[12px] font-semibold text-white shadow-lg shadow-[#5B3FA8]/30">
+                  Único cupo
+                </span>
+              ) : tier.featured ? (
                 <span className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-sunset px-3.5 py-1 text-[12px] font-semibold text-white shadow-lg shadow-sunset/30">
                   Más popular
                 </span>
-              )}
+              ) : null}
+
               <h3 className={`text-2xl font-bold tracking-tight ${tier.accent}`}>{tier.name}</h3>
+
               <div className="mt-3 flex items-baseline gap-1.5">
                 <span className="text-[2rem] font-bold leading-none tracking-tightest text-navy">
                   ${tier.priceMXN.toLocaleString("es-MX")}
                 </span>
                 <span className="text-sm font-semibold text-navy/50">MXN</span>
               </div>
+              <p className="mt-1 text-sm text-navy/50">
+                ≈ US$ {tier.priceUSD.toLocaleString("en-US")}
+              </p>
+              <p className="mt-1 text-[12px] font-medium uppercase tracking-wider text-navy/40">
+                {tier.seats}
+              </p>
+
               <p className="mt-3 min-h-[3rem] leading-relaxed text-navy/60">{tier.tagline}</p>
+              {tier.name === "Diamond" && (
+                <p className="mt-2 text-xs italic text-navy/50">
+                  Solo 1 patrocinador con este paquete por edición.
+                </p>
+              )}
+
+              {tier.keynote && (
+                <span className="mt-4 inline-flex w-fit items-center gap-1.5 rounded-full bg-ocean/10 px-3 py-1 text-xs font-semibold text-ocean">
+                  Incluye keynote 45 min + 15 Q&amp;A
+                </span>
+              )}
+              {tier.attendeeList && (
+                <span
+                  className={`mt-2 inline-flex w-fit items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold ${ATTENDEE_LIST_PILL[tier.attendeeList]}`}
+                >
+                  Lista de asistentes · {tier.attendeeList}
+                </span>
+              )}
+
               <ul className="mt-6 space-y-3 text-navy/75">
                 {tier.benefits.map((benefit) => (
                   <li key={benefit} className="flex items-start gap-3">
@@ -114,19 +224,96 @@ export default function Patrocinadores({ withHeader = true }: { withHeader?: boo
                   </li>
                 ))}
               </ul>
+
               <Link
                 href={`/?category=Sponsor&package=${tier.name}#contacto`}
-                className={`group mt-6 inline-flex w-full items-center justify-center gap-2.5 rounded-full py-3 text-[15px] font-semibold transition ${
-                  tier.featured
-                    ? "bg-sunset text-white hover:bg-sunset-400 active:scale-[0.98]"
-                    : "border border-navy/15 text-navy hover:bg-navy hover:text-white"
-                }`}
+                className={`group mt-6 flex w-full items-center justify-center gap-2 rounded-full px-4 py-3 text-[14px] font-semibold leading-tight transition ${ctaClasses(tier)}`}
               >
-                Elegir {tier.name}
-                <ArrowUpRight size={15} />
+                <span className="min-w-0 text-center">
+                  {tier.ctaLabel ?? `Elegir ${tier.name}`}
+                </span>
+                <ArrowUpRight size={15} className="shrink-0" />
               </Link>
             </div>
           ))}
+        </div>
+
+        {/* Ticket model + raffle */}
+        <div className="reveal rounded-3xl border border-navy/10 bg-cream p-8 lg:p-10">
+          <div className="grid gap-8 lg:grid-cols-2">
+            {/* Left — general admission */}
+            <div>
+              <span className="inline-block rounded-full bg-navy px-3 py-1 text-[12px] font-semibold text-white">
+                Boleto del evento
+              </span>
+              <h3 className="mt-4 text-2xl font-semibold tracking-tight text-navy">
+                Costo del evento — ${TICKET.priceMXN.toLocaleString("es-MX")} MXN (≈ US$ {TICKET.priceUSD})
+              </h3>
+              <p className="mt-3 leading-relaxed text-navy/70">
+                Tu boleto incluye la playera oficial del 7º Aniversario + acceso completo al evento.
+                Lo recaudado cubre la operación de la comunidad — sin fines de lucro.
+              </p>
+              <p className="mt-4 text-sm text-navy/50">
+                Los boletos cortesía del patrocinador NO se cobran y SÍ incluyen playera.
+              </p>
+            </div>
+
+            {/* Right — sponsor ticket mechanics */}
+            <div>
+              <span className="inline-block rounded-full bg-ocean/15 px-3 py-1 text-[12px] font-semibold text-ocean">
+                Boletos para patrocinadores
+              </span>
+              <h3 className="mt-4 text-2xl font-semibold tracking-tight text-navy">
+                Dos formas de usar tus cortesías
+              </h3>
+
+              <div className="mt-5 space-y-4">
+                <div className="rounded-2xl border border-navy/10 bg-cream-100 p-5">
+                  <div className="flex items-start gap-4">
+                    <span className="grid h-11 w-11 shrink-0 place-items-center rounded-xl bg-ocean/12 text-ocean">
+                      <Users size={20} />
+                    </span>
+                    <div>
+                      <h4 className="text-lg font-semibold tracking-tight text-navy">Para tu equipo</h4>
+                      <p className="mt-1 text-sm leading-relaxed text-navy/60">
+                        Llévalos al evento: colaboradores, clientes, prospectos o invitados estratégicos.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="rounded-2xl border border-navy/10 bg-cream-100 p-5">
+                  <div className="flex items-start gap-4">
+                    <span className="grid h-11 w-11 shrink-0 place-items-center rounded-xl bg-sunset/15 text-sunset">
+                      <Gift size={20} />
+                    </span>
+                    <div>
+                      <h4 className="text-lg font-semibold tracking-tight text-navy">
+                        Para una rifa en tus redes
+                      </h4>
+                      <p className="mt-1 text-sm leading-relaxed text-navy/60">
+                        Convierte tus boletos en una dinámica de redes sociales «presentada por tu
+                        marca». Playas on Tech amplifica el sorteo desde sus canales oficiales y el
+                        ganador recibe boleto + playera. Plus de engagement social y leads.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <p className="mt-5 text-xs font-medium text-navy/50">
+                Boletos cortesía por tier: Silver 2 · Gold 4 · Platinum 6 · Diamond 10 (máx)
+              </p>
+            </div>
+          </div>
+
+          {/* Attendee-list opt-in note — see Eventbrite TODO outside this PR */}
+          <p className="mx-auto mt-6 max-w-[60ch] text-center text-xs italic text-navy/50">
+            Los sponsors Gold, Platinum y Diamond reciben una lista con la información de los
+            asistentes que dan consentimiento explícito al registrarse (nombre, email, empresa,
+            rol). Para uso de marketing y/u ofertas laborales según los términos del acuerdo de
+            patrocinio.
+          </p>
         </div>
 
         {/* Media partners */}
@@ -163,11 +350,15 @@ export default function Patrocinadores({ withHeader = true }: { withHeader?: boo
         </div>
 
         <p className="reveal mt-8 text-center text-navy/60">
-          ¿Quieres un paquete a la medida?{" "}
-          <Link href="/?category=Sponsor&package=Custom#contacto" className="font-semibold text-ocean underline-offset-4 hover:underline">
-            Escríbenos
+          Solo el aniversario tiene esta estructura. Para ediciones bimestrales tenemos otro track
+          con paquetes desde $500 MXN —{" "}
+          <Link
+            href="/?category=Sponsor&package=Bimonthly#contacto"
+            className="font-semibold text-ocean underline-offset-4 hover:underline"
+          >
+            escríbenos
           </Link>{" "}
-          y lo armamos juntos.
+          para conocerlo.
         </p>
       </div>
     </section>

--- a/src/components/aniversario/event.ts
+++ b/src/components/aniversario/event.ts
@@ -29,7 +29,20 @@ export const ANIV_NAV = [
 // Sponsorship fundraising goal + link to the full breakdown of commitments.
 export const SPONSORSHIP = {
   goalMXN: 130000,
+  goalUSD: 7700, // rounded for display
+  // Mix: 1 Title + 2 Platinum + 4 Gold + 2 Silver = $130K exact.
   raisedMXN: 0, // update as sponsors confirm
   // TODO: swap for the full sponsorship deck (Notion / Google Doc / PDF) when ready.
   detailsUrl: "https://www.instagram.com/playasontech_mzo",
+} as const;
+
+// Public ticket — symbolic donation that funds the operation of the community.
+// Sponsor courtesy tickets do NOT charge this price but DO include the same shirt.
+export const TICKET = {
+  priceMXN: 150,
+  priceUSD: 9,
+  includes: [
+    "Acceso al evento completo",
+    "Playera oficial del 7º Aniversario",
+  ],
 } as const;


### PR DESCRIPTION
# Reestructura de paquetes de patrocinio: 3 → 4 tiers

Cambia `src/components/aniversario/Patrocinadores.tsx` de 3 a 4 tiers, agrega precios en USD, perks de keynote (Platinum + Diamond), exclusiva de naming \"Presentado por\" en Diamond, perk de lista de asistentes en Gold/Platinum/Diamond, y una nueva sección de modelo de boletos + rifa.

## 1 commit

`df86be6` — `feat(sponsors): 4-tier structure (Silver/Gold/Platinum/Diamond) with USD pricing, keynote callouts, attendee-list perk, raffle ticket model`

## Cambios principales

### Tipo `Tier` extendido
Nuevos campos opcionales: `priceUSD`, `seats`, `headline`, `keynote`, `attendeeList: \"Standard\" | \"Plus\" | \"Premium\"`, `ctaLabel`.

### 4 paquetes (antes 3)
| Tier | MXN | USD | Cupos | Highlights |
|---|---|---|---|---|
| Silver | $5,000 | US$300 | Sin límite | 9 beneficios, 2 boletos cortesía |
| Gold ⭐ | $10,000 | US$600 | Hasta 4 | featured, Lista de asistentes (Standard), 4 boletos |
| Platinum | $20,000 | US$1,200 | Hasta 2 | Keynote 45min+15 Q&A, Lista de asistentes (Plus), 6 boletos |
| Diamond 💎 | $40,000 | US$2,400 | **1 único** | headline, naming rights \"Presentado por\", keynote de apertura, Lista de asistentes (Premium), 10 boletos |

### Visual
- Grid: `lg:grid-cols-4` (antes `lg:grid-cols-3`), `md:grid-cols-2`, default 1-col en móvil.
- Cada card muestra MXN y USD, línea de cupos en small-caps, pill de keynote (Platinum + Diamond), pill de attendee-list color-coded por tier.
- Diamond tiene accent morado (\`#5B3FA8\`), badge \"Único cupo\", border distintivo, CTA \"Conversemos sobre Diamond\".

### Nueva sección \"Modelo de boletos + Rifa\"
Entre el grid de tiers y media-partners. Dos columnas:
- **Izquierda**: boleto del evento $150 MXN (≈US$9), incluye playera oficial.
- **Derecha**: \"Dos formas de usar tus cortesías\" — para tu equipo / para una rifa en tus redes (con icons Users + Gift).
- Nota informativa abajo sobre el opt-in de attendee-list que se gestiona vía Eventbrite.

### `event.ts`
- `TICKET` constant (price MXN/USD + includes array).
- `SPONSORSHIP.goalUSD: 7700` agregado al lado del `goalMXN: 130000`.

## Acceptance checks

- ✅ `npm run build` limpio
- ✅ `grep -c \"Presentado por\" Patrocinadores.tsx` = **1** (solo en Diamond)
- ✅ `grep -c \"keynote: true\"` = **2** (Platinum + Diamond)
- ✅ `grep -c \"attendeeList:\"` = **3** (Gold + Platinum + Diamond)
- ✅ Copy \"100% gratis\" en `StatsStrip.tsx`, `layout.tsx`, `Hero.tsx`, `Eventos.tsx` NO modificado (decisión de producto pendiente).
- ✅ \"Title\" como tier name → 0 ocurrencias (renombrado a \"Diamond\").

## Pendientes fuera de scope (notas para Osvaldo)

1. **\"100% gratis\" vs ticket de $150**: el copy en Hero/Stats/Layout sigue diciendo \"gratis\". Hay que decidir el messaging final.
2. **Eventbrite opt-in**: el perk de attendee-list requiere consentimiento explícito al registrarse. Agregar checkbox al form de Eventbrite con texto sugerido en el código (comentario en sección C-BIS).
3. **\`PatrocinadoresCta\`** (el teaser en \`/aniversario\`) sigue mostrando la estructura vieja de 3 tiers — pendiente para otro PR.
4. **Card-height imbalance**: Diamond con 15 perks queda visiblemente más alto que Silver con 9. Spec era explícito sobre 4 columnas en desktop — flagging por si quieres reorganizar.

## Notas de merge

- Branch cortado de \`main\`. Si \`feat/i18n-en\` (PR #7) se mergea primero, este PR necesita rebase + traducción al inglés de los nuevos strings (tier benefits, ticket section, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)