### PR TITLE
fix(ci): declarar packages en pnpm-workspace.yaml (deploy estaba fallando)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+packages:
+  - .
 allowBuilds:
   sharp: true
   unrs-resolver: true


### PR DESCRIPTION
## Bug

El deploy de hoy ([run #26519755531](https://github.com/playas-on-tech/playas-on-tech.github.io/actions/runs/26519755531)) falló en el step \`Setup Node.js\` con:

\`\`\`
ERROR  packages field missing or empty
For help, run: pnpm help store
\`\`\`

## Causa

\`actions/setup-node@v4\` con \`cache: 'pnpm'\` corre \`pnpm store path\` para configurar el cache. pnpm ve \`pnpm-workspace.yaml\` y asume estructura de workspace, pero el campo \`packages:\` no estaba declarado → error.

## Fix

Agregar \`packages: ['.']\` para declarar que es un workspace de un solo paquete (el root). Se conserva el bloque \`allowBuilds\` que ya estaba.

\`\`\`diff
+ packages:
+   - .
  allowBuilds:
    sharp: true
    unrs-resolver: true
\`\`\`

## Por qué merge urgente

El sitio en producción está stuck en la versión vieja porque ningún deploy puede correr hasta que esto se mergee. Después de merge, re-disparar el workflow `Build and Deploy Site` y debería pasar limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)