### PR TITLE
Reduce sponsor keynote slots to 15 minutes (no Q&A)

### DIFF
--- a/src/components/aniversario/Patrocinadores.tsx
+++ b/src/components/aniversario/Patrocinadores.tsx
@@ -71,7 +71,7 @@ const TIERS: Record<Lang, Tier[]> = {
       attendeeList: "Plus",
       benefits: [
         "Todo lo de Gold",
-        "Keynote técnico de 25 min + 5 min Q&A (slot principal de agenda)",
+        "Keynote técnico de 15 min (slot principal de agenda)",
         "Stand premium en venue",
         "Logo en intro/outro del video oficial del evento",
         "Post dedicado en redes pre-evento",
@@ -95,7 +95,7 @@ const TIERS: Record<Lang, Tier[]> = {
       benefits: [
         "Naming rights — «Presentado por [Marca]»",
         "Welcome desde el escenario (5 min)",
-        "Keynote de apertura — 25 min + 5 min Q&A",
+        "Keynote de apertura — 15 min",
         "Co-branded lockup en TODOS los assets del evento",
         "Recap video del evento, sponsoreado",
         "Playera oficial co-branded",
@@ -163,7 +163,7 @@ const TIERS: Record<Lang, Tier[]> = {
       attendeeList: "Plus",
       benefits: [
         "Everything in Gold",
-        "25-min technical keynote + 5-min Q&A (main agenda slot)",
+        "15-min technical keynote (main agenda slot)",
         "Premium stand at the venue",
         "Logo in intro/outro of the official event video",
         "Dedicated post on social media pre-event",
@@ -187,7 +187,7 @@ const TIERS: Record<Lang, Tier[]> = {
       benefits: [
         "Naming rights — «Presented by [Brand]»",
         "Welcome speech from the stage (5 min)",
-        "Opening keynote — 25 min + 5 min Q&A",
+        "Opening keynote — 15 min",
         "Co-branded lockup on ALL event assets",
         "Sponsored event recap video",
         "Co-branded official t-shirt",
@@ -228,7 +228,7 @@ const COPY = {
     morePopular: "Más popular",
     chooseLabel: "Elegir",
     singleSponsor: "Solo 1 patrocinador con este paquete por edición.",
-    keynoteLabel: "Incluye keynote 25 min + 5 Q&A",
+    keynoteLabel: "Incluye keynote de 15 min",
     attendeeListLabel: "Lista de asistentes",
     uniqueQuota: "Único cupo",
     
@@ -263,7 +263,7 @@ const COPY = {
     morePopular: "Most popular",
     chooseLabel: "Choose",
     singleSponsor: "Only 1 sponsor with this package per edition.",
-    keynoteLabel: "Includes 25 min keynote + 5 Q&A",
+    keynoteLabel: "Includes 15 min keynote",
     attendeeListLabel: "Attendee list",
     uniqueQuota: "Only slot",
     


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Quick Info
Updates Platinum and Diamond sponsorship copy on the anniversary sponsors page (Spanish and English).

---

### Migrations? :-1:

---

### What does this change?
- **Platinum:** keynote benefit is now a **15-minute** technical talk (was 25 min + 5 min Q&A).
- **Diamond:** opening keynote is now **15 minutes** (was 25 min + 5 min Q&A).
- Tier badge labels (`keynoteLabel`) updated to match in both locales.

Diamond’s separate **5-minute welcome** on stage is unchanged.

---

### Why are you changing that?
Sponsor keynote slots should be shorter and without a dedicated Q&A block.

---

### How did you accomplish this change?
Edited `src/components/aniversario/Patrocinadores.tsx` tier benefits and `COPY` labels for `es` and `en`.

---

### How do you manually test this?
1. `npm run dev`
2. Open `/aniversario/patrocinadores` and `/en/aniversario/sponsors`
3. Confirm Platinum and Diamond show 15-minute keynotes with no Q&A mention

---

### Screenshots (If Apply)
N/A — copy-only change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b4e6185-309e-43b8-86a2-ff5c2b5e712b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b4e6185-309e-43b8-86a2-ff5c2b5e712b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

