### PR TITLE
Default site language to Spanish, ignore browser locale

### DIFF
--- a/src/lib/LangProvider.tsx
+++ b/src/lib/LangProvider.tsx
@@ -13,14 +13,6 @@ function readCookie(): Lang | null {
   return null;
 }
 
-function detectBrowserLang(): Lang {
-  if (typeof navigator === "undefined") return "es";
-  for (const l of navigator.languages ?? []) {
-    if (l.startsWith("en")) return "en";
-  }
-  return "es";
-}
-
 interface LangContextValue {
   lang: Lang;
   setLang: (l: Lang) => void;
@@ -51,19 +43,12 @@ export function useLang(): LangContextValue {
 export default function LangProvider({ children }: { children: React.ReactNode }) {
   const [lang, setLangState] = useState<Lang>("es");
 
-  // Detect language on first mount only (no cookie → browser detection)
+  // Apply saved preference on first mount; default is Spanish
   useEffect(() => {
     const cookie = readCookie();
-    if (cookie) {
-      setLangState(cookie);
-      document.documentElement.lang = cookie;
-    } else {
-      const detected = detectBrowserLang();
-      if (detected !== "es") {
-        setLangState(detected);
-        document.documentElement.lang = detected;
-      }
-    }
+    if (!cookie) return;
+    setLangState(cookie);
+    document.documentElement.lang = cookie;
   }, []);
 
   const setLang = useCallback((l: Lang) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Quick Info
Language detection change — no migrations, no new dependencies.

---

### Migrations? :-1:
No.

---

### What does this change?
The site now always defaults to Spanish for new visitors. Browser language (`navigator.languages`) is no longer used to auto-select English.

Users who manually switch language via the header toggle still get their preference saved in the `playasontech_lang` cookie and restored on return visits.

---

### Why are you changing that?
The community site should present Spanish by default regardless of the visitor's browser or OS locale settings.

---

### How did you accomplish this change?
Removed `detectBrowserLang()` and the fallback branch in `LangProvider` that read `navigator.languages`. Initial state remains `"es"`; only an existing cookie overrides it.

---

### How do you manually test this?
1. Clear the `playasontech_lang` cookie (or use a private window).
2. Set your browser language to English.
3. Load the site — content should appear in Spanish.
4. Use the language toggle to switch to English — content updates and the cookie is set.
5. Reload — English persists from the cookie.

---

### Screenshots (If Apply)
N/A

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81bf5153-0517-4271-ac1f-622939c37162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81bf5153-0517-4271-ac1f-622939c37162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

