### PR TITLE
Upgrade CI from deprecated Node 20 actions to v6 / Node 22

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,17 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@types/node": "^20",
+    "@types/node": "^22",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "autoprefixer": "^10.4.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@types/node':
-        specifier: ^20
-        version: 20.19.41
+        specifier: ^22
+        version: 22.19.19
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.15
@@ -569,6 +569,9 @@ packages:
 
   '@types/node@20.19.41':
     resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
+
+  '@types/node@22.19.19':
+    resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -2679,6 +2682,10 @@ snapshots:
   '@types/json5@0.0.29': {}
 
   '@types/node@20.19.41':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/node@22.19.19':
     dependencies:
       undici-types: 6.21.0
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this change?

Updates the deploy workflow to use GitHub Actions that run on the Node 24 action runtime (`actions/checkout@v6`, `actions/setup-node@v6`, `pnpm/action-setup@v6`) and builds the site with Node 22 instead of Node 20. Bumps `@types/node` to `^22` to match.

### Why are you changing that?

CI logs report that Node.js 20 actions are deprecated. GitHub is migrating action runtimes from Node 20 to Node 24; older action major versions (e.g. `@v4`) still run on Node 20 and trigger deprecation warnings.

### How did you accomplish this change?

- Upgraded `actions/checkout`, `actions/setup-node`, and `pnpm/action-setup` from v4 to v6
- Set `node-version` to `22` (current LTS) for the build step
- Updated `@types/node` and `pnpm-lock.yaml` accordingly
- `peaceiris/actions-gh-pages@v4` already targets the Node 24 runtime in v4.1.0; left unchanged

### How do you manually test this?

- `pnpm install` and `npm run build` pass locally
- After merge, trigger the **Build and Deploy Site** workflow and confirm the deprecation warnings are gone
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13b5b3a3-fa6f-445e-a364-317d59c671b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13b5b3a3-fa6f-445e-a364-317d59c671b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

