### PR TITLE
fix: resolve mobile scroll & rendering issues on iPhone

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -224,6 +224,28 @@ body {
   50% { transform: translateY(-12px); }
 }
 
+/* Touch/mobile: remove expensive GPU filters to prevent scroll jank on iPhone */
+@media (hover: none) and (pointer: coarse) {
+  .reveal {
+    filter: none;
+    transform: translateY(20px) scale(0.99);
+    transition: opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1),
+                transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+  .reveal.is-visible {
+    transform: none;
+  }
+  .blob {
+    filter: blur(50px);
+    animation: none;
+    will-change: auto;
+  }
+  .blob-aqua,
+  .blob-sunset {
+    display: none;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .blob,
   .sticker,

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { ArrowUpRight } from "./Icons";
 import { useLang } from "@/lib/LangProvider";
@@ -36,10 +36,15 @@ const COPY = {
 
 export default function Header() {
   const [scrolled, setScrolled] = useState(false);
+  const scrolledRef = useRef(false);
 
   useEffect(() => {
     const handleScroll = () => {
-      setScrolled(window.scrollY > 20);
+      const isScrolled = window.scrollY > 20;
+      if (scrolledRef.current !== isScrolled) {
+        scrolledRef.current = isScrolled;
+        setScrolled(isScrolled);
+      }
     };
     handleScroll();
     window.addEventListener("scroll", handleScroll, { passive: true });

--- a/src/components/SiteEffects.tsx
+++ b/src/components/SiteEffects.tsx
@@ -64,12 +64,17 @@ export default function SiteEffects() {
     // 3. Cinematic scroll parallax — hero text drifts up and fades as you scroll
     const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     const heroContent = document.getElementById("hero-content");
+    // Viewport-relative fade: content fully fades at 85% of viewport height.
+    // Fixed 640px caused content to vanish while still visible on iPhone rubber-band overscroll.
+    const fadeDistance = window.innerHeight * 0.85;
     let ticking = false;
     const onScroll = () => {
       const y = window.scrollY;
       if (heroContent && y < window.innerHeight * 1.2) {
+        const opacity = Math.max(0, 1 - y / fadeDistance);
+        heroContent.style.opacity = String(opacity);
+        if (opacity <= 0) { ticking = false; return; }
         heroContent.style.transform = "translateY(" + y * 0.3 + "px)";
-        heroContent.style.opacity = String(Math.max(0, 1 - y / 640));
       }
       ticking = false;
     };

--- a/src/components/aniversario/AnivHeader.tsx
+++ b/src/components/aniversario/AnivHeader.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { ArrowUpRight } from "../Icons";
 import { anivNav } from "./event";
@@ -13,9 +13,16 @@ const COPY = {
 
 export default function AnivHeader() {
   const [scrolled, setScrolled] = useState(false);
+  const scrolledRef = useRef(false);
 
   useEffect(() => {
-    const handleScroll = () => setScrolled(window.scrollY > 20);
+    const handleScroll = () => {
+      const isScrolled = window.scrollY > 20;
+      if (scrolledRef.current !== isScrolled) {
+        scrolledRef.current = isScrolled;
+        setScrolled(isScrolled);
+      }
+    };
     handleScroll();
     window.addEventListener("scroll", handleScroll, { passive: true });
     return () => window.removeEventListener("scroll", handleScroll);


### PR DESCRIPTION
## Summary

- **Hero parallax opacity bug**: El umbral de fade estaba hardcoded a 640px. En iPhone, el efecto de rubber-band overscroll revelaba el hero con `opacity: 0`. Ahora usa `window.innerHeight * 0.85` como referencia viewport-relativa.
- **Header re-renders en scroll**: `Header` y `AnivHeader` llamaban `setState` en cada frame de scroll, causando re-renders de React con `backdrop-filter: blur(14px)` activo. Se agregó `useRef` para solo actualizar estado cuando el valor booleano cambia.
- **`filter: blur` en `.reveal` en mobile**: La animación de scroll-reveal animaba `blur(7px) → blur(0)` en decenas de elementos, saturando la GPU en iPhone. En touch devices se desactiva el blur, manteniendo solo el fade + translateY.
- **Blob animations en mobile**: Cuatro blobs de 24–52vw con `blur(80px)` y animaciones infinitas corrían siempre. En touch devices se eliminan las animaciones y se reduce el blur a 50px; los blobs aqua y sunset se ocultan.

## Páginas afectadas
`/` (home), `/aniversario`, `/patrocinadores`

## Test plan
- [ ] iPhone Safari: scroll rápido en `/` → el hero no desaparece abruptamente
- [ ] iPhone Safari: overscroll (rubber-band) al tope → el hero sigue visible con contenido
- [ ] Scroll-reveal en secciones (Statement, Venue, Videos) → aparece suavemente sin flashes
- [ ] `/aniversario` y `/patrocinadores`: header no genera jank al scrollear
- [ ] Desktop: animaciones de reveal con blur siguen funcionando (el media query es `hover: none` + `pointer: coarse`, no aplica en desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)