### PR TITLE
fix(aniversario): corregir conteo a catorce comunidades

### DIFF
--- a/src/components/aniversario/ComunidadesAliadas.tsx
+++ b/src/components/aniversario/ComunidadesAliadas.tsx
@@ -5,12 +5,12 @@ const COPY = {
   es: {
     pill: "Comunidades aliadas",
     h2: "Construido por la comunidad.",
-    sub: "Trece comunidades tech de todo México se unen al 7º aniversario para celebrar juntos frente al mar.",
+    sub: "Catorce comunidades tech de todo México se unen al 7º aniversario para celebrar juntos frente al mar.",
   },
   en: {
     pill: "Allied communities",
     h2: "Built by the community.",
-    sub: "Thirteen tech communities from across Mexico join the 7th anniversary to celebrate together by the sea.",
+    sub: "Fourteen tech communities from across Mexico join the 7th anniversary to celebrate together by the sea.",
   },
 } as const;
 


### PR DESCRIPTION
Corrige el texto del subtítulo de \"Trece\" a \"Catorce\" (es) y de \"Thirteen\" a \"Fourteen\" (en) tras agregar GDG Heroica Veracruz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)